### PR TITLE
Allow `Search` to bring back all recipes if no query provided

### DIFF
--- a/src/components/Helpers/Pagination.astro
+++ b/src/components/Helpers/Pagination.astro
@@ -2,12 +2,12 @@
 import { type PaginationProps } from '@/types/Pagination';
 import Container from '@/components/Container.astro';
 
-const { baseUrl, currentPage, totalPages } = Astro.props as PaginationProps;
+const { baseUrl, currentPage, forceQueryString, totalPages } = Astro.props as PaginationProps;
 
-function getPageUrl(page: number) {
+const getPageUrl = (page: number) => {
   const params = new URLSearchParams(Astro.url.searchParams);
 
-  const hasSearchParams = Array.from(params.keys()).length > 0;
+  const hasSearchParams = forceQueryString || Array.from(params.keys()).length > 0;
 
   if (!hasSearchParams) {
     return page === 1 ? baseUrl : `${baseUrl}${page}/`;
@@ -22,7 +22,7 @@ function getPageUrl(page: number) {
   return `${baseUrl}?${params.toString()}`;
 }
 
-function getPagination(current: number, total: number): (number | string)[] {
+const getPagination = (current: number, total: number): (number | string)[] => {
   const delta: (number) = 2;
   const range: (number | string)[] = [];
   const rangeWithDots: (number | string)[] = [];

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -24,33 +24,30 @@ let cuisines: { label: string; value: string }[] | null = null;
 let totalResults = 0;
 let totalPages = 0;
 
-if (query) {
-  if (query.length >= MIN_QUERY_LENGTH) {
+if (query && (query.length < MIN_QUERY_LENGTH)) {
+  error = `Search query must be at least ${MIN_QUERY_LENGTH} characters long.`;
+}
 
-    const res = await getRecipesFromSupabase({
-      query,
-      filters: {
-        cuisine: selectedCuisine,
-        time: selectedTime,
-      },
-      page,
-      sort,
-    });
+if (!error) {
+  const res = await getRecipesFromSupabase({
+    query,
+    filters: {
+      cuisine: selectedCuisine,
+      time: selectedTime,
+    },
+    page,
+    sort,
+  });
 
-    totalResults = res.count ?? 0;
-    totalPages = Math.ceil(totalResults / recipesPerPage);
+  totalResults = res.total;
+  totalPages = Math.ceil(totalResults / recipesPerPage);
 
-    data = res.data ?? [];
-    error = res.error?.message ? String(res.error.message) : (data?.length ? '' : 'No recipes found.');
-    cuisines = Array.from(
-      new Map(
-        data?.map(r => r.cuisine).filter(Boolean).map(c => [c.toLowerCase(), { label: c, value: c.toLowerCase() }])
-      ).values()
-    ).sort((a, b) => a.label.localeCompare(b.label));
-  }
-  else {
-    error = `Search query must be at least ${MIN_QUERY_LENGTH} characters long.`;
-  }
+  data = res.recipes ?? [];
+  cuisines = res.cuisines ?? [];
+
+  error = res.error?.message
+    ? String(res.error.message)
+    : (data?.length === 0 ? 'No recipes found.' : '');
 }
 
 const hasResults = (data && (data.length > 0));
@@ -153,6 +150,7 @@ const hasResults = (data && (data.length > 0));
     <Pagination
       baseUrl={`/search/`}
       currentPage={page}
+      forceQueryString={true}
       totalPages={totalPages}
     />
   )}
@@ -182,10 +180,6 @@ const hasResults = (data && (data.length > 0));
       const sort = form.querySelector('[name="sort"]')?.value;
       if (sort)
         params.set('sort', sort);
-
-      const page = new URLSearchParams(location.search).get('page');
-      if (page)
-        params.set('page', page);
 
       return params.toString();
     };

--- a/src/types/Pagination.ts
+++ b/src/types/Pagination.ts
@@ -1,5 +1,6 @@
 export interface PaginationProps {
   baseUrl: string;
   currentPage: number;
+  forceQueryString?: boolean;
   totalPages: number;
 }


### PR DESCRIPTION
This includes a quick hack to the Pagination component, because we need to force pagination by query string on the `/search/` URL, even when no params are passed through initially