### PR TITLE
Update `getBlogPosts` helper

### DIFF
--- a/src/helpers/getBlogPosts.ts
+++ b/src/helpers/getBlogPosts.ts
@@ -7,10 +7,12 @@ let blogCache: any[] | null = null;
 export const getBlogPosts = async (options: GetBlogPostsOptions = {}) => {
   if (!blogCache) {
     const blogPosts = await getCollection('blog');
+    const today = new Date();
 
-    blogCache = blogPosts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+    blogCache = blogPosts
+      .filter(post => (import.meta.env.MODE === 'production') ? (post.data.date <= today) : true)
+      .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
   }
 
-  // Apply limit if provided
-  return (typeof options.limit === 'number') ? blogCache?.slice(0, options.limit) : blogCache;
+  return (typeof options.limit === 'number') ? blogCache.slice(0, options.limit) : blogCache;
 };


### PR DESCRIPTION
We're now only going to showing blog posts with a current or past date when we're building for production.